### PR TITLE
Update dllhash.yml

### DIFF
--- a/.github/workflows/dllhash.yml
+++ b/.github/workflows/dllhash.yml
@@ -39,12 +39,7 @@ jobs:
             "Beta": "'$beta_hash'"
           }' > dll_hashes.json
 
-      - name: commit json
-        uses: actions/upload-artifact@v3
-        with:
-          name: dll-hashes
-          path: dll_hashes.json
-
+      
       - name: commit file with hashes
         if: success()
         run: |


### PR DESCRIPTION
remove artifact upload to stop github from blocking it for using deprecated version. There is no change to the end functionality for aetopia's launcher as it only checks the dll hashes json file, not the workflow artifact 