### PR TITLE
chore: upload latest Android APK

### DIFF
--- a/.github/workflows/r2-upload.yml
+++ b/.github/workflows/r2-upload.yml
@@ -7,6 +7,7 @@ on:
       - 'launcher/NewSupported.txt'
       - 'launcher/Supported.json'
       - 'launcher/Promotions.json'
+      - 'android/Flarial.apk'
   workflow_run:
     workflows: ["make hashbrowns"]
     types:
@@ -108,6 +109,15 @@ jobs:
             aws s3 cp 202.txt s3://${R2_BUCKET}/202.txt \
               --endpoint-url ${R2_ENDPOINT}
             echo "✓ Uploaded 202.txt"
+          fi
+
+
+          # Upload latest Android APK.
+
+          if [ -f "android/Flarial.apk" ]; then
+            aws s3 cp android/Flarial.apk s3://${R2_BUCKET}/android/Flarial.apk \
+              --endpoint-url ${R2_ENDPOINT}
+            echo "✓ Uploaded android/Flarial.apk"
           fi
 
           # Fetch latest version of Pyroclastic for the launcher to use.


### PR DESCRIPTION
## Goal
Publish the latest Android APK to the public CDN endpoint.

## Scope
- Upload or update android/Flarial.apk at https://cdn.flarial.xyz/android/Flarial.apk.
- Ensure the artifact matches the latest flarialmc/android main release build.
- Preserve the published SHA256 for verification.

## Acceptance Criteria
- [ ] The CDN serves the newest Android APK.
- [ ] The APK matches the expected release build.
- [ ] The published SHA256 is recorded for verification.

## Context
This is the Android distribution update that keeps the public download endpoint in sync with the latest build.

## Out of Scope
- Android code changes.
- CDN infrastructure changes.
- Release process redesign.