### PR TITLE
ci: add Android APK hash and CDN upload flow

### DIFF
--- a/.github/workflows/androidhash.yml
+++ b/.github/workflows/androidhash.yml
@@ -1,0 +1,48 @@
+name: make android hashbrowns
+
+on:
+  push:
+    paths:
+      - 'Android/Flarial.apk'
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  check_hash:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: checkout repo
+        uses: actions/checkout@v3
+
+      - name: check if Android APK exists
+        run: |
+          if [ ! -f "Android/Flarial.apk" ]; then
+            echo "File Android/Flarial.apk not found!"
+            exit 1
+          fi
+
+      - name: get hash for Android APK
+        run: |
+          apk_hash=$(sha256sum Android/Flarial.apk | awk '{ print $1 }')
+          cat > Android/AndroidHash.json <<EOF
+          {
+            "Android": "${apk_hash}"
+          }
+          EOF
+
+      - name: commit hash file
+        run: |
+          git config --global user.name "GitHub Actions"
+          git config --global user.email "actions@github.com"
+
+          git add Android/AndroidHash.json
+          if git diff --cached --quiet; then
+            echo "AndroidHash.json already up to date"
+            exit 0
+          fi
+
+          git commit -m "update Android hash"
+          git push

--- a/.github/workflows/r2-upload.yml
+++ b/.github/workflows/r2-upload.yml
@@ -7,8 +7,10 @@ on:
       - 'launcher/NewSupported.txt'
       - 'launcher/Supported.json'
       - 'launcher/Promotions.json'
+      - 'Android/Flarial.apk'
+      - 'Android/AndroidHash.json'
   workflow_run:
-    workflows: ["make hashbrowns"]
+    workflows: ["make hashbrowns", "make android hashbrowns"]
     types:
       - completed
   workflow_dispatch:
@@ -108,6 +110,20 @@ jobs:
             aws s3 cp 202.txt s3://${R2_BUCKET}/202.txt \
               --endpoint-url ${R2_ENDPOINT}
             echo "✓ Uploaded 202.txt"
+          fi
+
+          # Upload latest Android APK and hash metadata.
+
+          if [ -f "Android/Flarial.apk" ]; then
+            aws s3 cp Android/Flarial.apk s3://${R2_BUCKET}/Android/Flarial.apk \
+              --endpoint-url ${R2_ENDPOINT}
+            echo "✓ Uploaded Android/Flarial.apk"
+          fi
+
+          if [ -f "Android/AndroidHash.json" ]; then
+            aws s3 cp Android/AndroidHash.json s3://${R2_BUCKET}/Android/AndroidHash.json \
+              --endpoint-url ${R2_ENDPOINT}
+            echo "✓ Uploaded Android/AndroidHash.json"
           fi
 
           # Fetch latest version of Pyroclastic for the launcher to use.

--- a/Android/AndroidHash.json
+++ b/Android/AndroidHash.json
@@ -1,0 +1,3 @@
+{
+  "Android": "d66fdc38c8109eaad805e76a78fa0727dd6495cb55f126b3215093ede8fe25dc"
+}


### PR DESCRIPTION
Adds a capital Android CDN folder with:\n\n- Android/Flarial.apk\n- Android/AndroidHash.json\n\nAdds a GitHub Actions workflow that updates AndroidHash.json whenever Android/Flarial.apk changes, and updates the R2 upload workflow so both files are available from the CDN.\n\nInitial APK SHA256: d66fdc38c8109eaad805e76a78fa0727dd6495cb55f126b3215093ede8fe25dc