### PR TITLE
Quarantine revoked launcher artifact

### DIFF
--- a/.github/workflows/r2-upload.yml
+++ b/.github/workflows/r2-upload.yml
@@ -56,6 +56,10 @@ jobs:
             aws s3 cp launcher/Flarial.Launcher.exe s3://${R2_BUCKET}/launcher/Flarial.Launcher.exe \
               --endpoint-url ${R2_ENDPOINT}
             echo "✓ Uploaded Flarial.Launcher.exe"
+          else
+            aws s3 rm s3://${R2_BUCKET}/launcher/Flarial.Launcher.exe \
+              --endpoint-url ${R2_ENDPOINT}
+            echo "✓ Removed quarantined Flarial.Launcher.exe"
           fi
 
           # Upload DLL hashes metadata.


### PR DESCRIPTION
## Summary

- remove the quarantined Windows launcher executable from the CDN source
- delete the matching R2 object when the launcher file is absent

## Root cause

The published launcher SHA-256 `d66a17b6ee5fe8c333b7d1dfae9e32ba79630bc8186996fa91edfe0727faca97` is detected by 10 of 69 VirusTotal engines. VirusTotal also marks its signing certificate as revoked, so the artifact must no longer be distributed.

## Verification

- confirmed the deleted source file matches the quarantined SHA-256
- `git diff --check` passed
- the R2 workflow now handles both upload and deliberate removal states

The deleted binary remains recoverable from Git history for forensic comparison, but will no longer be served after the workflow completes.
