### PR TITLE
Restore launcher distribution to pre-VirusTotal state

### DIFF
--- a/.github/workflows/r2-upload.yml
+++ b/.github/workflows/r2-upload.yml
@@ -56,10 +56,6 @@ jobs:
             aws s3 cp launcher/Flarial.Launcher.exe s3://${R2_BUCKET}/launcher/Flarial.Launcher.exe \
               --endpoint-url ${R2_ENDPOINT}
             echo "✓ Uploaded Flarial.Launcher.exe"
-          else
-            aws s3 rm s3://${R2_BUCKET}/launcher/Flarial.Launcher.exe \
-              --endpoint-url ${R2_ENDPOINT}
-            echo "✓ Removed quarantined Flarial.Launcher.exe"
           fi
 
           # Upload DLL hashes metadata.


### PR DESCRIPTION
Reverts PR #10 and restores launcher/Flarial.Launcher.exe plus the prior R2 synchronization behavior.