### PR TITLE
Fix and publish Android 1.3.4 release pair

### DIFF
--- a/.github/workflows/androidhash.yml
+++ b/.github/workflows/androidhash.yml
@@ -24,30 +24,68 @@ jobs:
             exit 1
           fi
 
-      - name: update Android version metadata
+      - name: update Android release metadata from APK
         run: |
-          android_version=$(jq -r '.versionName // .Android // empty' Android/AndroidHash.json)
-          if [ -z "$android_version" ]; then
-            echo "Android version metadata is missing"
+          set -euo pipefail
+
+          apkanalyzer_bin="$(command -v apkanalyzer || true)"
+          if [ -z "${apkanalyzer_bin}" ]; then
+            for candidate in \
+              "${ANDROID_SDK_ROOT:-}/cmdline-tools/latest/bin/apkanalyzer" \
+              "${ANDROID_HOME:-}/cmdline-tools/latest/bin/apkanalyzer" \
+              "${ANDROID_HOME:-}/tools/bin/apkanalyzer"; do
+              if [ -x "${candidate}" ]; then
+                apkanalyzer_bin="${candidate}"
+                break
+              fi
+            done
+          fi
+          if [ -z "${apkanalyzer_bin}" ]; then
+            echo "apkanalyzer was not found in the GitHub-hosted Android SDK" >&2
             exit 1
           fi
-          cat > Android/AndroidHash.json <<EOF
-          {
-            "Android": "${android_version}",
-            "versionName": "${android_version}"
-          }
-          EOF
 
-      - name: commit version metadata file
+          apk_hash="$(sha256sum Android/Flarial.apk | awk '{ print $1 }')"
+          version_name="$("${apkanalyzer_bin}" manifest version-name Android/Flarial.apk)"
+          version_code="$("${apkanalyzer_bin}" manifest version-code Android/Flarial.apk)"
+          is_play_store_back="$(jq -r '.isPlayStoreBack // false' Android/AndroidHash.json 2>/dev/null || printf 'false')"
+
+          if ! [[ "${apk_hash}" =~ ^[0-9a-f]{64}$ ]]; then
+            echo "Could not calculate the APK SHA-256" >&2
+            exit 1
+          fi
+          if [ -z "${version_name}" ] || [ "${version_name}" = "null" ]; then
+            echo "Could not read versionName from the APK manifest" >&2
+            exit 1
+          fi
+          if ! [[ "${version_code}" =~ ^[0-9]+$ ]]; then
+            echo "Could not read a numeric versionCode from the APK manifest" >&2
+            exit 1
+          fi
+          if [ "${is_play_store_back}" != "true" ] && [ "${is_play_store_back}" != "false" ]; then
+            echo "isPlayStoreBack must be a JSON boolean" >&2
+            exit 1
+          fi
+
+          jq -n \
+            --arg hash "${apk_hash}" \
+            --arg versionName "${version_name}" \
+            --argjson versionCode "${version_code}" \
+            --argjson isPlayStoreBack "${is_play_store_back}" \
+            '{Android: $hash, versionName: $versionName, versionCode: $versionCode, isPlayStoreBack: $isPlayStoreBack}' \
+            > Android/AndroidHash.json.tmp
+          mv Android/AndroidHash.json.tmp Android/AndroidHash.json
+
+      - name: commit Android release metadata
         run: |
           git config --global user.name "GitHub Actions"
           git config --global user.email "actions@github.com"
 
           git add Android/AndroidHash.json
           if git diff --cached --quiet; then
-            echo "AndroidHash.json version metadata already up to date"
+            echo "AndroidHash.json release metadata already up to date"
             exit 0
           fi
 
-          git commit -m "update Android version metadata"
+          git commit -m "update Android release metadata"
           git push

--- a/.github/workflows/r2-upload.yml
+++ b/.github/workflows/r2-upload.yml
@@ -17,10 +17,10 @@ on:
       # Android/Flarial.apk pushes. The Android hash workflow commits
       # AndroidHash.json immediately after the APK changes; uploading on the
       # APK push creates a race where R2 can serve a new APK with the old hash.
-      # Let the workflow_run from "make android hashbrowns" publish the
+      # Let the workflow_run from "update android version metadata" publish the
       # validated APK+hash pair atomically instead.
   workflow_run:
-    workflows: ["make hashbrowns", "make android hashbrowns"]
+    workflows: ["make hashbrowns", "update android version metadata"]
     types:
       - completed
   workflow_dispatch:

--- a/Android/AndroidHash.json
+++ b/Android/AndroidHash.json
@@ -1,4 +1,6 @@
 {
-  "Android": "1.3.3",
-  "versionName": "1.3.3"
+  "Android": "1407fd9815c0544b1cf1cab4649aaa26f0d3912f483db790b8eded4f582e29fe",
+  "versionName": "1.3.4",
+  "versionCode": 2026080601,
+  "isPlayStoreBack": false
 }


### PR DESCRIPTION
## Summary

- restore the Android 1.3.4 APK SHA-256, version name, numeric version code, and rollout flag
- derive future Android release metadata directly from the APK with the GitHub-hosted Android SDK instead of copying stale JSON values
- make the R2 publisher watch the metadata workflow's exact current name
- keep the guarded atomic upload of the APK and metadata to both `/Android/` and legacy `/android/` paths

## Verified release

- Package: `com.flarialmc.flarial_launcher`
- Version: `1.3.4` (`2026080601`)
- Minimum SDK: 28 / Android 9
- Size: `24,006,174` bytes
- SHA-256: `1407fd9815c0544b1cf1cab4649aaa26f0d3912f483db790b8eded4f582e29fe`
- APK Signature Scheme v2 verified
- Signing-certificate SHA-256 unchanged: `6217be5a3838417fdfc9a4645e32f7150a9d185ef4c14686839df398da778f6b`

## Validation

- workflow YAML parsed successfully
- `workflow_run.workflows` exactly matches producer name `update android version metadata`
- metadata-generation step simulated against a temporary APK/JSON pair and produced the exact expected object
- checked-in JSON checksum exactly matches the APK
- `git diff --check` passed

## Publication consequence

The branch push used the repository's established `[skip actions]` convention, so it must not publish from the feature branch. Merging this PR changes `.github/workflows/r2-upload.yml`, which intentionally triggers the guarded R2 publisher from `main`. That run should publish the verified 1.3.4 APK and metadata pair to both uppercase and lowercase CDN paths.